### PR TITLE
Update sender name length error

### DIFF
--- a/src/services/message.services.ts
+++ b/src/services/message.services.ts
@@ -15,7 +15,7 @@ const sendMessage = async (message: string, senderName?: string, options?: IMess
   }
 
   if (senderName && senderName.length > SENDER_NAME_MAX_LENGTH) {
-    throw new Error("Your name cannot be more than 200 character");
+    throw new Error(`Your name cannot be more than ${SENDER_NAME_MAX_LENGTH} characters`);
   }
 
   return app


### PR DESCRIPTION
## Summary
- fix message service to reference `SENDER_NAME_MAX_LENGTH`

## Testing
- `yarn install`
- `yarn lint`
- `yarn check-types`


------
https://chatgpt.com/codex/tasks/task_e_685ba81bc36083308ded3acbe1c19761