### PR TITLE
Add blog: cursor vs codex

### DIFF
--- a/content/blogs/cursor-vs-codex.mdx
+++ b/content/blogs/cursor-vs-codex.mdx
@@ -1,0 +1,21 @@
+---
+title: Cursor vs Codex
+publishedAt: 2025-08-01
+description: A short take comparing Cursor, the AI-powered editor, with OpenAI's Codex.
+language: en
+coverImage: hello-world-3.jpg
+---
+
+I have been trying two different AI coding helpers recently: **Cursor** and **Codex**. Cursor ships as a full code editor that integrates AI chat and code generation directly in the editor window. Codex is the model powering a number of assistants including GitHub Copilot.
+
+## Cursor
+
+Cursor feels like using VS Code with an AI pair programmer attached. You can ask questions inline, generate code, or refactor a selection. Because it is a full editor, it can understand your project context without any extra setup.
+
+## Codex
+
+Codex is an API that turns natural language into code. Tools like Copilot build on top of it to provide suggestions in your editor. The quality of completions depends on how the tool integrates with Codex and the prompts it sends.
+
+## Which one should you use?
+
+If you want an all-in-one editor experience with AI built in, Cursor is great. If you prefer staying in your current editor and leveraging AI suggestions there, Codex-powered tools might fit better. Both are impressive leaps in developer tooling, and the best choice largely depends on your workflow.


### PR DESCRIPTION
## Summary
- add a short blog comparing Cursor and Codex

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn check-types` *(fails: package not present in lockfile)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6873d25e1080833085658d9bb049d2dc